### PR TITLE
Remove personal absolute paths from reenrich fixture script

### DIFF
--- a/scripts/regenerate_fixtures/README.md
+++ b/scripts/regenerate_fixtures/README.md
@@ -19,9 +19,12 @@ fresh copy, pull it from there and re-upload as the `fixtures/v1` asset.
 
 ## Scripts
 
-- `reenrich_ibm_concise.py` — parses the IBM 2025 annual report PDF with
-  Docling, then runs `DoclingEnrichingAgent` with a one-phrase summary
-  prompt. Produces `ibm_annual_report_enriched_concise.json`.
+- `reenrich_ibm_concise.py` — loads a Docling-parsed IBM 2025 annual report
+  JSON, then runs `DoclingEnrichingAgent` with a one-phrase summary prompt.
+  Produces `ibm_annual_report_enriched_concise.json`. You must supply the
+  parsed JSON yourself — it is not committed to the repo. Either drop it at
+  `notebooks/fixtures/ibm_annual_report_parsed.json` or point the
+  `IBM_PARSED_JSON` environment variable at its location.
 
 ## Regeneration workflow
 
@@ -38,9 +41,10 @@ uv pip install \
 python scripts/regenerate_fixtures/reenrich_ibm_concise.py
 ```
 
-Note: the script uses hardcoded source and destination paths (see the script for details).
-If you need to regenerate from a different source PDF or write to a different location,
-edit the script's `src` and `dst` variables before running.
+The script writes to `notebooks/fixtures/ibm_annual_report_enriched_concise.json`,
+overwriting the committed fixture in-place. Source defaults to
+`notebooks/fixtures/ibm_annual_report_parsed.json`; override with `IBM_PARSED_JSON`
+if your parsed JSON lives elsewhere.
 
 Upload the new asset, overwriting the existing `fixtures/v1` release:
 

--- a/scripts/regenerate_fixtures/reenrich_ibm_concise.py
+++ b/scripts/regenerate_fixtures/reenrich_ibm_concise.py
@@ -63,8 +63,13 @@ DoclingEnrichingAgent._generate_summary = _patched_generate_summary
 # --- Go ---
 assert os.environ.get("REPLICATE_API_TOKEN"), "Set REPLICATE_API_TOKEN first"
 
-src = Path("/Users/mingxuanzhao/scratch/chunkless-rag-tutorial/ibm_annual_report_parsed.json")
-dst = Path("/Users/mingxuanzhao/scratch/chunkless-rag-tutorial/ibm_annual_report_enriched_concise.json")
+# Paths default to <repo>/notebooks/fixtures/. The parsed-JSON source is not
+# committed to the repo; either drop it at the default path or point IBM_PARSED_JSON
+# at it. The destination overwrites the committed fixture in-place.
+FIXTURES = Path(__file__).resolve().parents[2] / "notebooks" / "fixtures"
+src = Path(os.environ.get("IBM_PARSED_JSON", FIXTURES / "ibm_annual_report_parsed.json"))
+dst = FIXTURES / "ibm_annual_report_enriched_concise.json"
+assert src.exists(), f"Source parsed JSON not found at {src}. Set IBM_PARSED_JSON or place the file at the default path."
 
 doc = DoclingDocument.load_from_json(src)
 


### PR DESCRIPTION
- Previously mistakenly targeted local folder, default both paths to `notebooks/fixtures/` relative to the repo root