### PR TITLE
Let attendees parse and enrich their own PDF in chunkless RAG notebook

### DIFF
--- a/notebooks/Chunkless_RAG.ipynb
+++ b/notebooks/Chunkless_RAG.ipynb
@@ -28,13 +28,13 @@
     "\n",
     "This tutorial throws both of those out.\n",
     "\n",
-    "We're going to ask the same kind of question against the same kind of document, but with **no chunker, no embedding model, and no vector store**. Instead, we'll let the LLM **navigate the document's own structural tree** \u2014 picking sections by reading their summaries, the way a human researcher skims a table of contents \u2014 and answer from whatever section it lands on.\n",
+    "We're going to ask the same kind of question against the same kind of document, but with **no chunker, no embedding model, and no vector store**. Instead, we'll let the LLM **navigate the document's own structural tree** — picking sections by reading their summaries, the way a human researcher skims a table of contents — and answer from whatever section it lands on.\n",
     "\n",
     "This is what `docling-agent` calls a **chunkless RAG agent** (`DoclingRAGAgent`). It only works because Docling has already done the hard work of recovering real document structure from the source PDF. By the end of this notebook you'll know:\n",
     "\n",
     "1. How chunkless navigation actually works (it's roughly 80 lines of loop, not magic).\n",
     "2. How to run it on a pre-enriched `DoclingDocument`, and how to enrich your own.\n",
-    "3. When to reach for it instead of hybrid-chunking RAG \u2014 and when not to."
+    "3. When to reach for it instead of hybrid-chunking RAG — and when not to."
    ]
   },
   {
@@ -94,7 +94,7 @@
     "# Ollama; this cell patches it to pick a backend based on the BACKEND global\n",
     "# above. We patch every module that binds `setup_local_session` at import\n",
     "# time (Python's `from X import Y` creates a separate reference). This\n",
-    "# keeps the docling-agent source untouched \u2014 everything lives in the notebook.\n",
+    "# keeps the docling-agent source untouched — everything lives in the notebook.\n",
     "#\n",
     "# docling-agent 0.1.0 imports `setup_local_session` in six modules:\n",
     "#   - docling_agent.agent.rag           (exercised by DoclingRAGAgent)\n",
@@ -158,35 +158,35 @@
     "Chunkless retrieval is a four-step loop:\n",
     "\n",
     "```\n",
-    "                   \u250c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2510\n",
-    "                   \u2502       Document outline               \u2502\n",
-    "                   \u2502    (per-section summaries)           \u2502\n",
-    "                   \u2514\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2518\n",
-    "                                   \u2502\n",
-    "                                   \u25bc\n",
-    " \u250c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2510\n",
-    " \u2502 1. SELECT  \u2014 LLM picks the most relevant unvisited       \u2502\n",
-    " \u2502              section by reading the outline + query.     \u2502\n",
-    " \u2514\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2518\n",
-    "                                   \u2502\n",
-    "                                   \u25bc\n",
-    " \u250c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2510\n",
-    " \u2502 2. FETCH   \u2014 Pull the *full text* of that section's      \u2502\n",
-    " \u2502              subtree from the DoclingDocument.           \u2502\n",
-    " \u2514\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2518\n",
-    "                                   \u2502\n",
-    "                                   \u25bc\n",
-    " \u250c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2510\n",
-    " \u2502 3. ATTEMPT \u2014 LLM tries to answer from the section text.  \u2502\n",
-    " \u2502              Returns {can_answer: bool, response: str}.  \u2502\n",
-    " \u2514\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2518\n",
-    "                                   \u2502\n",
-    "                      \u250c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2534\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2510\n",
-    "                      \u25bc                         \u25bc\n",
+    "                   ┌──────────────────────────────────────┐\n",
+    "                   │       Document outline               │\n",
+    "                   │    (per-section summaries)           │\n",
+    "                   └──────────────────────────────────────┘\n",
+    "                                   │\n",
+    "                                   ▼\n",
+    " ┌──────────────────────────────────────────────────────────┐\n",
+    " │ 1. SELECT  — LLM picks the most relevant unvisited       │\n",
+    " │              section by reading the outline + query.     │\n",
+    " └──────────────────────────────────────────────────────────┘\n",
+    "                                   │\n",
+    "                                   ▼\n",
+    " ┌──────────────────────────────────────────────────────────┐\n",
+    " │ 2. FETCH   — Pull the *full text* of that section's      │\n",
+    " │              subtree from the DoclingDocument.           │\n",
+    " └──────────────────────────────────────────────────────────┘\n",
+    "                                   │\n",
+    "                                   ▼\n",
+    " ┌──────────────────────────────────────────────────────────┐\n",
+    " │ 3. ATTEMPT — LLM tries to answer from the section text.  │\n",
+    " │              Returns {can_answer: bool, response: str}.  │\n",
+    " └──────────────────────────────────────────────────────────┘\n",
+    "                                   │\n",
+    "                      ┌────────────┴────────────┐\n",
+    "                      ▼                         ▼\n",
     "              can_answer = true          can_answer = false\n",
-    "                      \u2502                         \u2502\n",
-    "                      \u25bc                         \u25bc\n",
-    "                return answer           4. ITERATE \u2014 go back\n",
+    "                      │                         │\n",
+    "                      ▼                         ▼\n",
+    "                return answer           4. ITERATE — go back\n",
     "                                        to SELECT, with the\n",
     "                                        visited section excluded.\n",
     "```\n",
@@ -195,7 +195,7 @@
     "\n",
     "This only works because two things are already true about the input document:\n",
     "\n",
-    "1. It's a **`DoclingDocument`** \u2014 a real tree with sections, paragraphs, tables, and figures, parsed by Docling from the source PDF.\n",
+    "1. It's a **`DoclingDocument`** — a real tree with sections, paragraphs, tables, and figures, parsed by Docling from the source PDF.\n",
     "2. Each section already has a **summary attached as metadata**, written by `DoclingEnrichingAgent` in a one-time enrichment pass.\n",
     "\n",
     "We'll use a fixture that already has both. If you want to run this on your own PDF, there's an optional cell a few steps down that shows you how."
@@ -206,11 +206,19 @@
    "id": "5",
    "metadata": {},
    "source": [
-    "## Loading a pre-enriched document\n",
+    "## Loading a document\n",
     "\n",
-    "We'll work with the **Docling tech report** (`arXiv:2408.09869v5`) \u2014 a 10-page academic paper with ~20 well-defined sections covering Docling's architecture, AI models, performance benchmarks, and applications. It ships pre-enriched as a fixture in `docling-agent`'s test data, so every section header already carries an LLM-written summary in its metadata.\n",
+    "We'll start with the **Docling tech report** (`arXiv:2408.09869v5`) — a 10-page academic paper with ~20 well-defined sections covering Docling's architecture, AI models, performance benchmarks, and applications. It ships pre-enriched as a fixture in `docling-agent`'s test data, so every section header already carries an LLM-written summary in its metadata.\n",
     "\n",
-    "> **Want to use your own PDF?** Skip ahead to the optional **\"Enriching your own PDF\"** cell below. Just be aware that enrichment runs an LLM call per section and takes several minutes on a long document."
+    "**Want to use your own PDF?** Set `MY_PDF` in the next cell to a URL or a local file path. The cell will parse it with Docling and enrich it with `DoclingEnrichingAgent` before running queries. Leave `MY_PDF = None` to use the fixture.\n",
+    "\n",
+    "A few things to know before you flip the switch:\n",
+    "\n",
+    "- Enrichment makes ~1-2 LLM calls per eligible section (and per table or captioned figure); very short or empty sections cost nothing. The tech-report fixture has ~20 sections and finishes in a few minutes on Replicate.\n",
+    "- A 50-page PDF typically has ~100 sections — budget proportionally more time, much longer on Ollama with a local model.\n",
+    "- Failures are silent: the cell finishes even if some sections don't get summarized. The cell prints a final count of items that received summaries so you can sanity-check.\n",
+    "- The notebook caches the enriched result next to your PDF so re-running doesn't re-pay the enrichment cost.\n",
+    "- **Query 1 and Query 3 below are written for the Docling tech report.** If you supply your own PDF, you'll want to edit those queries to ask things your document can actually answer."
    ]
   },
   {
@@ -220,10 +228,16 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import re\n",
+    "from urllib.parse import urlparse\n",
     "from urllib.request import urlretrieve\n",
     "\n",
     "FIXTURES = Path(\"fixtures\")\n",
     "FIXTURES.mkdir(exist_ok=True)\n",
+    "\n",
+    "# Set MY_PDF to a URL or a local path to parse and enrich your own document.\n",
+    "# Leave it as None to load the pre-enriched Docling tech report fixture.\n",
+    "MY_PDF = None\n",
     "\n",
     "fixture_path = FIXTURES / \"2408.09869v5-hierarchical-with-summaries.json\"\n",
     "fixture_url = (\n",
@@ -231,54 +245,78 @@
     "    \"releases/download/fixtures/v1/\"\n",
     "    \"2408.09869v5-hierarchical-with-summaries.json\"\n",
     ")\n",
-    "if not fixture_path.exists():\n",
-    "    print(f\"Downloading fixture to {fixture_path} ...\")\n",
-    "    urlretrieve(fixture_url, fixture_path)\n",
     "\n",
-    "doc = DoclingDocument.load_from_json(fixture_path)\n",
-    "print(f\"Loaded document: {doc.name!r}\")\n",
-    "print(f\"Total items in tree: {sum(1 for _ in doc.iterate_items())}\")"
+    "if MY_PDF is None:\n",
+    "    if not fixture_path.exists():\n",
+    "        print(f\"Downloading fixture to {fixture_path} ...\")\n",
+    "        urlretrieve(fixture_url, fixture_path)\n",
+    "    doc = DoclingDocument.load_from_json(fixture_path)\n",
+    "    print(f\"Loaded document: {doc.name!r}\")\n",
+    "    print(f\"Total items in tree: {sum(1 for _ in doc.iterate_items())}\")\n",
+    "else:\n",
+    "    # Derive a cache path next to (or inside FIXTURES for URLs) the source PDF.\n",
+    "    parsed_url = urlparse(MY_PDF)\n",
+    "    if parsed_url.scheme in (\"http\", \"https\"):\n",
+    "        # Use the full last URL segment (not Path.stem, which truncates at\n",
+    "        # the first dot — important for arxiv-style IDs like 2408.09869v5)\n",
+    "        # and sanitize so the filename is filesystem-safe.\n",
+    "        raw_name = Path(parsed_url.path).name or \"byo_document\"\n",
+    "        no_ext = re.sub(r\"\\.pdf$\", \"\", raw_name, flags=re.IGNORECASE)\n",
+    "        cache_stem = re.sub(r\"[^A-Za-z0-9._-]\", \"_\", no_ext) or \"byo_document\"\n",
+    "        cache_path = FIXTURES / f\"{cache_stem}.enriched.json\"\n",
+    "    else:\n",
+    "        cache_path = Path(MY_PDF).with_suffix(\".enriched.json\")\n",
+    "\n",
+    "    if cache_path.exists():\n",
+    "        print(f\"Loading cached enriched document from {cache_path} ...\")\n",
+    "        doc = DoclingDocument.load_from_json(cache_path)\n",
+    "    else:\n",
+    "        # Import here to keep the default fixture path import-light.\n",
+    "        import requests\n",
+    "        from docling.document_converter import DocumentConverter\n",
+    "        from docling.datamodel.base_models import ConversionStatus\n",
+    "\n",
+    "        print(f\"Parsing {MY_PDF} with Docling ...\")\n",
+    "        try:\n",
+    "            result = DocumentConverter().convert(MY_PDF)\n",
+    "        except (requests.RequestException, FileNotFoundError, ValueError) as e:\n",
+    "            print(\n",
+    "                f\"Could not load {MY_PDF!r}. Check the path or URL is correct, \"\n",
+    "                \"the file exists (for local paths), and it points to a PDF.\"\n",
+    "            )\n",
+    "            raise\n",
+    "        if result.status != ConversionStatus.SUCCESS:\n",
+    "            print(f\"WARNING: Docling reported status {result.status!r}; \"\n",
+    "                  \"the parsed document may be incomplete.\")\n",
+    "        parsed = result.document\n",
+    "\n",
+    "        # Call _summarize_items directly (not enricher.run) for two reasons:\n",
+    "        # 1. fix_heading_levels=True invokes DoclingEditingAgent, whose backend\n",
+    "        #    is not patched in the routing cell above (would silently use\n",
+    "        #    default Ollama).\n",
+    "        # 2. Skipping the heading-level repair pass avoids an extra LLM call.\n",
+    "        # Caveat: PDFs with malformed heading levels will produce wrong-scope\n",
+    "        # summaries — start with a well-structured document.\n",
+    "        print(\"Enriching with one-phrase section summaries ...\")\n",
+    "        enricher = DoclingEnrichingAgent(model_id=MODEL_ID, tools=[])\n",
+    "        doc = enricher._summarize_items(\n",
+    "            document=parsed, fix_heading_levels=False, loop_budget=2,\n",
+    "        )\n",
+    "        doc.save_as_json(cache_path)\n",
+    "        print(f\"Saved enriched document to {cache_path} (re-runs will be instant)\")\n",
+    "\n",
+    "    enriched_count = sum(\n",
+    "        1 for t in doc.texts\n",
+    "        if getattr(getattr(t, \"meta\", None), \"summary\", None)\n",
+    "    )\n",
+    "    print(f\"Loaded document: {doc.name!r}\")\n",
+    "    print(f\"Items with summaries: {enriched_count}\")\n",
+    "    print(f\"Total items in tree: {sum(1 for _ in doc.iterate_items())}\")"
    ]
   },
   {
    "cell_type": "markdown",
    "id": "7",
-   "metadata": {},
-   "source": [
-    "### Optional: enriching your own PDF\n",
-    "\n",
-    "The cell below shows how to start from a raw PDF instead of the shipped fixture. **Skip it unless you're adapting the notebook to your own document** \u2014 it parses a PDF with Docling, then runs `DoclingEnrichingAgent` to attach a summary to every section, which makes one LLM call per section and can take several minutes on a long paper."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "8",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# --- Optional: enrich your own PDF ---\n",
-    "# Uncomment and edit MY_PDF to point at a real PDF on your machine.\n",
-    "# Then re-run this cell instead of the previous \"load fixture\" cell.\n",
-    "\n",
-    "# from docling.document_converter import DocumentConverter\n",
-    "#\n",
-    "# MY_PDF = Path(\"/path/to/your/document.pdf\")\n",
-    "#\n",
-    "# converter = DocumentConverter()\n",
-    "# parsed = converter.convert(str(MY_PDF)).document\n",
-    "#\n",
-    "# enricher = DoclingEnrichingAgent(model_id=MODEL_ID, tools=[])\n",
-    "# doc = enricher.run(\n",
-    "#     task=\"Summarize each section header.\",\n",
-    "#     document=parsed,\n",
-    "# )\n",
-    "# print(f\"Enriched document: {doc.name!r}\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "9",
    "metadata": {},
    "source": [
     "## What the \"index\" actually looks like\n",
@@ -289,7 +327,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "10",
+   "id": "8",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -299,7 +337,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "11",
+   "id": "9",
    "metadata": {},
    "source": [
     "That's it. That's the entire retrieval state. No vectors, no nearest-neighbor index, no embedding model. A single markdown blob, generated once when the document was enriched, that fits comfortably in any LLM's context window.\n",
@@ -309,18 +347,20 @@
   },
   {
    "cell_type": "markdown",
-   "id": "12",
+   "id": "10",
    "metadata": {},
    "source": [
-    "## Query 1 \u2014 the happy path\n",
+    "## Query 1 — the happy path\n",
     "\n",
-    "Let's start with a question whose answer lives entirely in one section. We'd expect the agent to pick that section on its first try and answer immediately."
+    "Let's start with a question whose answer lives entirely in one section. We'd expect the agent to pick that section on its first try and answer immediately.\n",
+    "\n",
+    "> **Using your own PDF?** Edit `query_1` below to ask something your document can answer."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "13",
+   "id": "11",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -337,38 +377,40 @@
   },
   {
    "cell_type": "markdown",
-   "id": "14",
+   "id": "12",
    "metadata": {},
    "source": [
     "Walk through what just happened, top to bottom:\n",
     "\n",
-    "1. **Setup panel** \u2014 the agent counted available section refs and noted the iteration budget.\n",
-    "2. **Section Selection** \u2014 the LLM read the outline (with summaries), picked exactly one section ref, and gave its reason in plain English.\n",
-    "3. **Section Content** \u2014 the agent fetched only that section's subtree from the `DoclingDocument`. The full document was never put in the prompt.\n",
-    "4. **Answer Attempt** \u2014 the LLM read the section text and decided it had enough to answer. `can_answer = true`.\n",
-    "5. **Final Answer** \u2014 the loop converged in **one iteration**.\n",
+    "1. **Setup panel** — the agent counted available section refs and noted the iteration budget.\n",
+    "2. **Section Selection** — the LLM read the outline (with summaries), picked exactly one section ref, and gave its reason in plain English.\n",
+    "3. **Section Content** — the agent fetched only that section's subtree from the `DoclingDocument`. The full document was never put in the prompt.\n",
+    "4. **Answer Attempt** — the LLM read the section text and decided it had enough to answer. `can_answer = true`.\n",
+    "5. **Final Answer** — the loop converged in **one iteration**.\n",
     "\n",
     "This is the system on its best behavior. The next query is harder."
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "15",
+   "id": "13",
    "metadata": {},
    "source": [
-    "## Query 2 \u2014 where chunkless RAG actually earns its keep\n",
+    "## Query 2 — where chunkless RAG actually earns its keep\n",
     "\n",
     "Query 1 was easy. The document is 10 pages; every section is rich and self-contained; the summaries are precise enough that the right section is the first pick. On a document like that, *any* retrieval method (embedding-based, BM25, random guess) would probably work.\n",
     "\n",
-    "To see where chunkless RAG actually earns its keep, we need a bigger, messier document \u2014 the kind a real RAG system deals with. Something with hundreds of sections, stub page-headers, repeated layout fragments, and answers that live two levels deeper than the obvious first pick.\n",
+    "To see where chunkless RAG actually earns its keep, we need a bigger, messier document — the kind a real RAG system deals with. Something with hundreds of sections, stub page-headers, repeated layout fragments, and answers that live two levels deeper than the obvious first pick.\n",
     "\n",
-    "So we swap in IBM's 2025 annual report (the enriched version we prepared earlier with concise topical summaries). Same agent, same loop, same model \u2014 different document."
+    "So we swap in IBM's 2025 annual report (the enriched version we prepared earlier with concise topical summaries). Same agent, same loop, same model — different document.\n",
+    "\n",
+    "> **Using your own PDF?** Query 2 deliberately switches to a pre-enriched IBM annual report to demonstrate multi-hop behavior on a known-messy document. Your PDF returns for Query 3."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "16",
+   "id": "14",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -397,7 +439,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "17",
+   "id": "15",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -416,37 +458,39 @@
   },
   {
    "cell_type": "markdown",
-   "id": "18",
+   "id": "16",
    "metadata": {},
    "source": [
     "The trace tells a different story this time.\n",
     "\n",
-    "**Iteration 1** \u2014 the agent picks `#/texts/162`, a section headed \"Software\". In the outline that entry has no summary \u2014 it's a bare heading. When the agent fetches content, it gets back 8 characters: the word \"Software.\" That's because `#/texts/162` is a stub section in the source PDF \u2014 a page-level label, not a prose section. The agent reads what it got, sees it's nowhere near enough, and marks `can_answer = false`.\n",
+    "**Iteration 1** — the agent picks `#/texts/162`, a section headed \"Software\". In the outline that entry has no summary — it's a bare heading. When the agent fetches content, it gets back 8 characters: the word \"Software.\" That's because `#/texts/162` is a stub section in the source PDF — a page-level label, not a prose section. The agent reads what it got, sees it's nowhere near enough, and marks `can_answer = false`.\n",
     "\n",
-    "**Iteration 2** \u2014 with the stub now excluded from `unvisited`, the agent consults the remaining outline. This time the best match isn't by heading but by summary: `#/texts/167` has the unassuming heading \"Management Discussion,\" but its summary reads *\"IBM Software Segment Revenue Performance in 2025.\"* The agent picks it, fetches ~2,300 characters of actual prose \u2014 Red Hat's revenue growth, the segment's percentage contribution \u2014 and answers.\n",
+    "**Iteration 2** — with the stub now excluded from `unvisited`, the agent consults the remaining outline. This time the best match isn't by heading but by summary: `#/texts/167` has the unassuming heading \"Management Discussion,\" but its summary reads *\"IBM Software Segment Revenue Performance in 2025.\"* The agent picks it, fetches ~2,300 characters of actual prose — Red Hat's revenue growth, the segment's percentage contribution — and answers.\n",
     "\n",
     "Two things worth calling out:\n",
     "\n",
     "- **The agent navigated by summaries, not by keywords.** The obvious heading-match (\"Software\") was a dead end; the useful section had an opaque heading but a descriptive summary. In a pure keyword-search or embedding-similarity world, the stub would have won on name match.\n",
-    "- **The agent admitted insufficiency.** When iter 1 came back with 8 chars, the answer step was honest \u2014 `can_answer = false` \u2014 rather than fabricating something plausible from that thin context. That honesty is what makes the iteration loop useful; without it, the agent would have stopped at the wrong section.\n",
+    "- **The agent admitted insufficiency.** When iter 1 came back with 8 chars, the answer step was honest — `can_answer = false` — rather than fabricating something plausible from that thin context. That honesty is what makes the iteration loop useful; without it, the agent would have stopped at the wrong section.\n",
     "\n",
-    "This is the core multi-hop mechanic of chunkless RAG: read summaries, pick, read content, reconsider, pick again. No embeddings, no vector index, no cosine similarity scores \u2014 just the document's structure and the model's judgment."
+    "This is the core multi-hop mechanic of chunkless RAG: read summaries, pick, read content, reconsider, pick again. No embeddings, no vector index, no cosine similarity scores — just the document's structure and the model's judgment."
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "19",
+   "id": "17",
    "metadata": {},
    "source": [
-    "## Query 3 \u2014 what happens when the answer isn't in the document\n",
+    "## Query 3 — what happens when the answer isn't in the document\n",
     "\n",
-    "Now a question the document genuinely can't answer. Watch what the agent does."
+    "Now a question the document genuinely can't answer. Watch what the agent does.\n",
+    "\n",
+    "> **Using your own PDF?** Edit `query_3` below to ask something your document genuinely doesn't contain."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "20",
+   "id": "18",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -456,34 +500,34 @@
   },
   {
    "cell_type": "markdown",
-   "id": "21",
+   "id": "19",
    "metadata": {},
    "source": [
     "Notice three things about that trace:\n",
     "\n",
-    "1. **The agent did iterate.** It tried multiple sections in good faith \u2014 \"maybe there's a pricing section,\" \"maybe there's a licensing section,\" \"maybe there's a commercial offering section.\"\n",
+    "1. **The agent did iterate.** It tried multiple sections in good faith — \"maybe there's a pricing section,\" \"maybe there's a licensing section,\" \"maybe there's a commercial offering section.\"\n",
     "2. **It ran out the clock.** When it hit `max_iterations` without converging, it returned a `Partial Answer` rather than guessing.\n",
     "3. **It did not invent a number.** This is the single most important property of chunkless RAG for high-stakes use cases: there is no \"top-k of vaguely-related chunks\" to seduce the model into producing a confident-sounding but ungrounded answer. Either a section actually contains the information, or it doesn't.\n",
     "\n",
-    "(If your model *did* fabricate an answer here, that's a property of the model, not the retrieval system \u2014 chunkless RAG can't cure dishonest models, it just gives them less to riff on.)"
+    "(If your model *did* fabricate an answer here, that's a property of the model, not the retrieval system — chunkless RAG can't cure dishonest models, it just gives them less to riff on.)"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "22",
+   "id": "20",
    "metadata": {},
    "source": [
     "## Side-by-side: chunkless vs. hybrid chunking\n",
     "\n",
     "Both approaches can answer Query 1. They produce differently-shaped answers, and the difference is the whole point of this tutorial.\n",
     "\n",
-    "To make the comparison concrete, let's run a minimal hybrid-chunking RAG pipeline against the same tech report, with the same model, and look at what comes out. We'll use `HybridChunker` from `docling-core` to break the document into chunks, rank them by lexical overlap with the query (a lightweight stand-in for vector search \u2014 a production pipeline would use embeddings), and feed the top 3 to Granite as context.\n"
+    "To make the comparison concrete, let's run a minimal hybrid-chunking RAG pipeline against the same tech report, with the same model, and look at what comes out. We'll use `HybridChunker` from `docling-core` to break the document into chunks, rank them by lexical overlap with the query (a lightweight stand-in for vector search — a production pipeline would use embeddings), and feed the top 3 to Granite as context.\n"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "23",
+   "id": "21",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -533,7 +577,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "24",
+   "id": "22",
    "metadata": {},
    "source": [
     "Look at the *shape* of the two answers.\n",
@@ -549,18 +593,18 @@
     "\n",
     "**Chunkless `DoclingRAGAgent` answered:**\n",
     "\n",
-    "> The main AI models used in Docling are: 1) a layout analysis model \u2013 an accurate object\u2011detector for page elements (based on an RT\u2011DETR architecture) that predicts bounding boxes and classes for elements such as text, figures, tables, etc.; and 2) TableFormer, a state\u2011of\u2011the\u2011art vision\u2011transformer model for recognizing the logical row and column structure of tables, including handling merged cells, spans, and hierarchy. Both models are released with pre\u2011trained weights on Hugging Face and are provided via the docling\u2011ibm\u2011models package.\n",
+    "> The main AI models used in Docling are: 1) a layout analysis model – an accurate object‑detector for page elements (based on an RT‑DETR architecture) that predicts bounding boxes and classes for elements such as text, figures, tables, etc.; and 2) TableFormer, a state‑of‑the‑art vision‑transformer model for recognizing the logical row and column structure of tables, including handling merged cells, spans, and hierarchy. Both models are released with pre‑trained weights on Hugging Face and are provided via the docling‑ibm‑models package.\n",
     "\n",
-    "The hybrid answer is an **extraction**: it returns what its top-ranked chunks literally contained, lightly stitched together. The top-3 chunks on this query were the *introduction*, the *processing pipeline overview*, and the *PDF backends* subsection \u2014 all of which mention AI models in passing but don't actually name them. Section 3.2 (\"AI models\"), which names RT-DETR and TableFormer, didn't make the top 3 on lexical score. The answer is hedgy because the evidence is: the model correctly refused to invent names that weren't in its context.\n",
+    "The hybrid answer is an **extraction**: it returns what its top-ranked chunks literally contained, lightly stitched together. The top-3 chunks on this query were the *introduction*, the *processing pipeline overview*, and the *PDF backends* subsection — all of which mention AI models in passing but don't actually name them. Section 3.2 (\"AI models\"), which names RT-DETR and TableFormer, didn't make the top 3 on lexical score. The answer is hedgy because the evidence is: the model correctly refused to invent names that weren't in its context.\n",
     "\n",
     "The chunkless answer is a **synthesis**: the agent reasoned over the outline, picked the one section that was explicitly about the question (`#/texts/49`, titled \"AI models\"), read the whole section at once, and produced a grounded, specific answer on the first iteration. No chunk boundary cut through the subsection structure, so the model saw RT-DETR and TableFormer described together the way they were written.\n",
     "\n",
-    "Neither is universally better. If you want the exact sentence where a keyword appears, hybrid can do that cheaply. If you want an answer grounded in the author's original section structure \u2014 including lists, sub-headings, and tables that chunking would fragment \u2014 chunkless wins. They're answering subtly different questions, and the right choice depends on what your reader actually needs."
+    "Neither is universally better. If you want the exact sentence where a keyword appears, hybrid can do that cheaply. If you want an answer grounded in the author's original section structure — including lists, sub-headings, and tables that chunking would fragment — chunkless wins. They're answering subtly different questions, and the right choice depends on what your reader actually needs."
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "25",
+   "id": "23",
    "metadata": {},
    "source": [
     "## When to reach for which\n",
@@ -580,12 +624,12 @@
     "| **Audit trail** | Cosine scores | Plain-English \"I picked this section because...\" |\n",
     "| **Failure mode** | Returns unrelated chunks | Wastes an iteration, falls back gracefully |\n",
     "\n",
-    "**Rule of thumb:** if your reader's question is *\"find the sentence that says X,\"* reach for hybrid chunking. If it's *\"explain how the document handles X,\"* reach for chunkless. And if you're not sure \u2014 try chunkless first on a single representative document. It needs no extra infrastructure, the verbose trace tells you exactly what it did, and you can swap to hybrid chunking later if you outgrow it."
+    "**Rule of thumb:** if your reader's question is *\"find the sentence that says X,\"* reach for hybrid chunking. If it's *\"explain how the document handles X,\"* reach for chunkless. And if you're not sure — try chunkless first on a single representative document. It needs no extra infrastructure, the verbose trace tells you exactly what it did, and you can swap to hybrid chunking later if you outgrow it."
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "26",
+   "id": "24",
    "metadata": {},
    "source": [
     "## Where to go next\n",
@@ -594,12 +638,12 @@
     "\n",
     "**Knobs you can turn.** Two parameters do most of the work:\n",
     "\n",
-    "- `max_iterations` \u2014 how many sections the agent is allowed to consult before giving up. Default 5. Lower it for tight latency budgets, raise it for harder questions over longer documents.\n",
-    "- `verbose` \u2014 turns the rich-console trace on or off. Set it to `False` in production. The structured iteration history is still available on the `RAGResult` object if you need to log or audit it.\n",
+    "- `max_iterations` — how many sections the agent is allowed to consult before giving up. Default 5. Lower it for tight latency budgets, raise it for harder questions over longer documents.\n",
+    "- `verbose` — turns the rich-console trace on or off. Set it to `False` in production. The structured iteration history is still available on the `RAGResult` object if you need to log or audit it.\n",
     "\n",
     "**What we didn't cover.** `DoclingRAGAgent` also supports passing multiple documents through `sources=[...]`. It runs the loop once per document and then synthesizes a final answer from the per-document partials via `_merge_answers`. That's a natural follow-up if you're building something that needs to span more than one paper at a time.\n",
     "\n",
-    "**The bigger picture.** The reason chunkless RAG works at all is that Docling has already done the structural parsing. Every approach in this notebook \u2014 outline navigation, per-section summaries, subtree fetching \u2014 is downstream of \"Docling parsed a real tree out of this PDF.\" If you're working with documents that *don't* have real structure (chat logs, OCR'd forms, scanned receipts), this technique falls back to \"return the whole document,\" and hybrid chunking is the better tool for that job."
+    "**The bigger picture.** The reason chunkless RAG works at all is that Docling has already done the structural parsing. Every approach in this notebook — outline navigation, per-section summaries, subtree fetching — is downstream of \"Docling parsed a real tree out of this PDF.\" If you're working with documents that *don't* have real structure (chat logs, OCR'd forms, scanned receipts), this technique falls back to \"return the whole document,\" and hybrid chunking is the better tool for that job."
    ]
   }
  ],


### PR DESCRIPTION
Adds an optional `MY_PDF` switch to the chunkless RAG notebook so attendees can point at their own document (URL or local path). The default `MY_PDF = None` keeps the existing fixture flow.